### PR TITLE
Add key stores

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,10 @@ AllCops:
   TargetRubyVersion: 2.5
 
 Naming/UncommunicativeMethodParamName:
-  AllowedNames: [ iv ]
+  AllowedNames:
+    - iv
+    - id
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/*_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,8 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
+# Optional depdendency
+gem 'net-ssh'
+
 # Specify your gem's dependencies in keepasshttp.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
+    net-ssh (5.0.2)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -28,6 +29,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   keepasshttp!
+  net-ssh
   rake (~> 10.0)
   rspec (~> 3.0)
 

--- a/README.md
+++ b/README.md
@@ -20,13 +20,31 @@ Or install it yourself as:
 
 ## Usage
 
-```
-require 'keepass'
+```ruby
+require 'keepasshttp'
 
-keep = Keepass.connect
+keep = Keepasshttp.connect
 
-keep.password_for('http://example.com')
+keep.credentials_for('http://example.com')
 ```
+
+### KeyStores
+
+With the above code you'll be prompted by your Keepass to enter a label for the new key (because the tool generates a new key every time)
+which is shorter that typing your password but still annoying. So I added a (session) key_store. At the moment you can choose between:
+
+  * :Plain - save your key in plaintext - maximum convienience, minimal security
+    ```ruby
+      Keepasshttp.connect(key_store: :Plain)
+    ```
+  * :SshAgent - (re)use your running ssh-agent session to encrypt your session key (and then save it to a file)
+    ```ruby
+      Keepasshttp.connect(key_store: :SshAgent)
+    ```
+  * { key:, id: } - Do the keymanagement yourself and just input the necessary keys as Hash.
+    ```ruby
+      Keepasshttp.connect(key_store: { key: 'SECRET', id: 'Foo' })
+    ```
 
 ## Development
 
@@ -37,7 +55,7 @@ To install this gem onto your local machine, run `bundle exec rake install`.
 To see if it works run
 
 ```bash
-$ keepasshttp URL_THAT_IS_IN_YOUR_KEEPASSDB
+$ keepasshttp URL_THAT_IS_IN_YOUR_KEEPASSDB [OPTS]
 ```
 
 If it works Keypass will prompt you for a label (which name you pick is irrelevant) and it should print you an json to the shell containing your data.

--- a/exe/keepasshttp
+++ b/exe/keepasshttp
@@ -4,5 +4,20 @@
 require 'bundler/setup'
 require 'keepasshttp'
 require 'json'
+require 'optparse'
 
-puts Keepasshttp.connect.password_for(ARGV[0]).to_json
+params = {}
+
+ARGV.options do |opts|
+  opts.on('-p INTEGER', '--port', 'Use Keystore::Plain') do |val|
+    params[:port] = val.to_i
+  end
+
+  opts.on('--plain', 'Use Keystore::Plain') do
+    params[:key_store] = :Plain
+  end
+
+  opts.parse!
+end
+
+puts Keepasshttp.connect(params).credentials_for(ARGV[0]).to_json

--- a/exe/keepasshttp
+++ b/exe/keepasshttp
@@ -21,6 +21,16 @@ ARGV.options do |opts|
     params[:key_store] = :SshAgent
   end
 
+  opts.on('--key STRING', 'Input your key directly') do |val|
+    params[:key_store] ||= {}
+    params[:key_store][:key] = val
+  end
+
+  opts.on('--id STRING', 'Input your id directly') do |val|
+    params[:key_store] ||= {}
+    params[:key_store][:id] = val
+  end
+
   opts.parse!
 end
 

--- a/exe/keepasshttp
+++ b/exe/keepasshttp
@@ -17,6 +17,10 @@ ARGV.options do |opts|
     params[:key_store] = :Plain
   end
 
+  opts.on('--ssh-agent', 'Use Keystore::SshAgent') do
+    params[:key_store] = :SshAgent
+  end
+
   opts.parse!
 end
 

--- a/lib/keepasshttp/key_store.rb
+++ b/lib/keepasshttp/key_store.rb
@@ -4,6 +4,26 @@ require 'yaml'
 
 class Keepasshttp
   module KeyStore
+    # Input the key and the id directly into the client so you can take care
+    # of the storage yourself.
+    class External
+      def initialize(key:, id:)
+        @params = { key: key, id: id }
+      end
+
+      def save(*_args)
+        false
+      end
+
+      def load
+        @params
+      end
+
+      def available?
+        true
+      end
+    end
+
     # The most simple but unsecure way wo store your session key (so you don't
     # have to reenter the label over and over again). Use this only for testing!
     class Plain

--- a/lib/keepasshttp/key_store.rb
+++ b/lib/keepasshttp/key_store.rb
@@ -21,5 +21,67 @@ class Keepasshttp
         File.exist?(PATH) && File.size(PATH).positive?
       end
     end
+
+    # Use your running ssh-agent session to encrypt your session key
+    class SshAgent < Plain
+      class << self
+        def available?
+          require 'net/ssh'
+
+          super
+        rescue LoadError
+          raise LoadError, 'To use key_store: :SshAgent you have to install ' \
+                           "the 'net-ssh' gem"
+        end
+
+        def save(params = {})
+          enc, iv = encrypt(params.delete(:key))
+          params[:key] = enc
+          params[:iv] = iv
+          super(params)
+        end
+
+        def load
+          params = super
+          params[:key] = decrypt(params[:key], iv: params.delete(:iv))
+          params
+        end
+
+        private
+
+        def encrypt(string)
+          agent = Net::SSH::Authentication::Agent.connect
+
+          cip = OpenSSL::Cipher.new('AES-256-CBC')
+          cip.encrypt
+          iv = cip.random_iv
+
+          cip.key = agent.sign(identity(agent), iv)[-32..-1]
+
+          [cip.update(string) + cip.final, iv]
+        end
+
+        def decrypt(string, iv:)
+          agent = Net::SSH::Authentication::Agent.connect
+
+          cip = OpenSSL::Cipher.new('AES-256-CBC')
+          cip.decrypt
+          cip.iv = iv
+
+          cip.key = agent.sign(identity(agent), iv)[-32..-1]
+
+          cip.update(string) + cip.final
+        end
+
+        # TODO, make the key selectable
+        def identity(agent)
+          if agent.identities.empty?
+            raise 'No identity available. Run `ssh-add` and try again'
+          end
+
+          agent.identities.first
+        end
+      end
+    end
   end
 end

--- a/lib/keepasshttp/key_store.rb
+++ b/lib/keepasshttp/key_store.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+class Keepasshttp
+  module KeyStore
+    # The most simple but unsecure way wo store your session key (so you don't
+    # have to reenter the label over and over again). Use this only for testing!
+    class Plain
+      # TODO, make the PATH adjustable
+      PATH = File.join(Dir.home, '.keepasshttp-ruby')
+      def self.save(params = {})
+        File.write(PATH, params.to_yaml)
+      end
+
+      def self.load
+        YAML.load_file(PATH)
+      end
+
+      def self.available?
+        File.exist?(PATH) && File.size(PATH).positive?
+      end
+    end
+  end
+end

--- a/spec/keepasshttp_spec.rb
+++ b/spec/keepasshttp_spec.rb
@@ -47,4 +47,34 @@ RSpec.describe Keepasshttp do
       )
     end
   end
+
+  context 'Client' do
+    it 'can login to an opened Keepass' do
+      kee = Keepasshttp.connect
+      expect(kee.id).to eq('Test')
+    end
+
+    it 'can login to can store the credentials in a key_store' do
+      File.delete(Keepasshttp::KeyStore::Plain::PATH)
+
+      kee = Keepasshttp.connect(key_store: :Plain)
+      expect(kee.id).to eq('Test')
+
+      kee = Keepasshttp.connect(key_store: :Plain)
+      expect(kee.id).to eq('Test')
+    end
+
+    it 'can request credentials' do
+      kee = Keepasshttp.connect(key_store: :Plain)
+
+      expect(kee.credentials_for('example.com')).to eq(
+        [{
+          'Login' => 'foo',
+          'Name' => 'example.com',
+          'Password' => 'secret',
+          'Uuid' => 'A3BE9660BC4BDC45B69806D212D933B4'
+        }]
+      )
+    end
+  end
 end

--- a/spec/keepasshttp_spec.rb
+++ b/spec/keepasshttp_spec.rb
@@ -5,7 +5,22 @@ RSpec.describe Keepasshttp do
     expect(Keepasshttp::VERSION).not_to be nil
   end
 
-  it 'does something useful' do
-    expect(false).to eq(true)
+  context 'Keepasshttp::KeyStore' do
+    it 'has a Plain format' do
+      expect(Keepasshttp::KeyStore::Plain.available?).to be(true)
+      Keepasshttp::KeyStore::Plain.save(id: 'Foo', key: '1234567890')
+
+      expect(File.read(Keepasshttp::KeyStore::Plain::PATH)).to eq(<<~YAML)
+        ---
+        :id: Foo
+        :key: '1234567890'
+      YAML
+    end
+
+    it 'can load from Plain' do
+      expect(Keepasshttp::KeyStore::Plain.load).to eq(
+        id: 'Foo', key: '1234567890'
+      )
+    end
   end
 end

--- a/spec/keepasshttp_spec.rb
+++ b/spec/keepasshttp_spec.rb
@@ -15,10 +15,24 @@ RSpec.describe Keepasshttp do
         :id: Foo
         :key: '1234567890'
       YAML
+
+      expect(Keepasshttp::KeyStore::Plain.load).to eq(
+        id: 'Foo', key: '1234567890'
+      )
     end
 
-    it 'can load from Plain' do
-      expect(Keepasshttp::KeyStore::Plain.load).to eq(
+    it 'has an SshAgent format (encrypted Plain)' do
+      expect(Keepasshttp::KeyStore::SshAgent.available?).to be(true)
+
+      Keepasshttp::KeyStore::SshAgent.save(id: 'Foo', key: '1234567890')
+
+      cfg_file = File.read(Keepasshttp::KeyStore::Plain::PATH)
+      expect(cfg_file).to match(/id: Foo/)
+      expect(cfg_file).to match(/key:/)
+      expect(cfg_file).to_not match(/1234567890/)
+      expect(cfg_file).to match(/iv:/)
+
+      expect(Keepasshttp::KeyStore::SshAgent.load).to eq(
         id: 'Foo', key: '1234567890'
       )
     end

--- a/spec/keepasshttp_spec.rb
+++ b/spec/keepasshttp_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe Keepasshttp do
   end
 
   context 'Keepasshttp::KeyStore' do
+    it 'has a External format' do
+      ext = Keepasshttp::KeyStore::External.new(id: 'Foo', key: '1234567890')
+
+      expect(ext.available?).to be(true)
+      expect(ext.save(id: 'Bar', key: '0987654321')).to be(false)
+      expect(ext.load).to eq(
+        id: 'Foo', key: '1234567890'
+      )
+    end
+
     it 'has a Plain format' do
       expect(Keepasshttp::KeyStore::Plain.available?).to be(true)
       Keepasshttp::KeyStore::Plain.save(id: 'Foo', key: '1234567890')


### PR DESCRIPTION
Typing a label in every time you use it is kind of annoying so provide some mechanics to store the session key.

  * **Plain store** - just write it as-is to a File - maximum convenience, minimal security
  * **SshAgent** - if you're like me and have a ssh-agent *permanently* running you can reuse this session to store your key encrypted. Still convenient, better security.