### PR TITLE
Keystore and Formatting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,6 @@ Naming/UncommunicativeMethodParamName:
 Metrics/BlockLength:
   Exclude:
     - spec/*_spec.rb
+
+Metrics/MethodLength:
+  Max: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# CHANGELOG
+## Next Release
+  * Add KeyStore autodetection
+  * Add KeyStore::Environment
+  * **(changed default)** `key_store: :auto` (was `false`)
+  * **(changed behaviour)** key_store :auto will choose KeyStore::Environment
+    as fallback
+  * Add Formatter
+
+## Minor Release v0.2.0 (2018-10-01)
+  * Add KeyStores to save the keepasshttp credentials for later use
+
+## Minor Release v0.1.1 (2018-09-25)
+  * Add LICENCE (MIT)
+
+## Minor Release v0.1.0 (2018-09-25)
+  * First working version

--- a/exe/keepasshttp
+++ b/exe/keepasshttp
@@ -1,16 +1,21 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'bundler/setup'
 require 'keepasshttp'
 require 'json'
 require 'optparse'
 
 params = {}
+params[:key_store] = :auto
 
-ARGV.options do |opts|
-  opts.on('-p INTEGER', '--port', 'Use Keystore::Plain') do |val|
-    params[:port] = val.to_i
+ARGV.options do |opts| # rubocop:disable Metrics/BlockLength
+  opts.banner = 'keepasshttp [options] URL [URL]'
+  opts.on('-p INTEGER', '--port', 'Set the keepasshttp port [19422]') do |port|
+    params[:port] = port.to_i
+  end
+
+  opts.on('--no-keystore', "Don't save the credentials") do
+    params[:key_store] = false
   end
 
   opts.on('--plain', 'Use Keystore::Plain') do
@@ -21,17 +26,30 @@ ARGV.options do |opts|
     params[:key_store] = :SshAgent
   end
 
-  opts.on('--key STRING', 'Input your key directly') do |val|
-    params[:key_store] ||= {}
-    params[:key_store][:key] = val
+  opts.on('--token ID:KEY', 'Input your credentials') do |token|
+    params[:key_store] ||= token
   end
 
-  opts.on('--id STRING', 'Input your id directly') do |val|
-    params[:key_store] ||= {}
-    params[:key_store][:id] = val
+  opts.on('--environment', 'Use the KEEPASSHTTP_CREDENTIALS variable') do
+    params[:key_store] = :Environment
+  end
+
+  opts.on('-f', '--format STYLE', 'Choose output formater. [json]') do |style|
+    output_format = style
   end
 
   opts.parse!
+
+  if ARGV.empty?
+    puts opts
+    exit(1)
+  end
 end
 
-puts Keepasshttp.connect(params).credentials_for(ARGV[0]).to_json
+begin
+  puts Keepasshttp.connect(params).formatted_credentials_for(ARGV, output_format)
+rescue StandardError => err
+  warn err.message
+  exit(1)
+end
+

--- a/exe/keepasshttp
+++ b/exe/keepasshttp
@@ -7,6 +7,7 @@ require 'optparse'
 
 params = {}
 params[:key_store] = :auto
+output_style = :json
 
 ARGV.options do |opts| # rubocop:disable Metrics/BlockLength
   opts.banner = 'keepasshttp [options] URL [URL]'
@@ -35,7 +36,7 @@ ARGV.options do |opts| # rubocop:disable Metrics/BlockLength
   end
 
   opts.on('-f', '--format STYLE', 'Choose output formater. [json]') do |style|
-    output_format = style
+    output_style = style
   end
 
   opts.parse!
@@ -47,9 +48,8 @@ ARGV.options do |opts| # rubocop:disable Metrics/BlockLength
 end
 
 begin
-  puts Keepasshttp.connect(params).formatted_credentials_for(ARGV, output_format)
-rescue StandardError => err
-  warn err.message
+  puts Keepasshttp.connect(params).formatted_credentials_for(ARGV, output_style)
+rescue StandardError => e
+  warn e.message
   exit(1)
 end
-

--- a/lib/core_ext.rb
+++ b/lib/core_ext.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Provide String.to_base64 as refinement
+module Base64Helper
+  refine String do
+    def to_base64
+      [self].pack('m*').chomp
+    end
+
+    def from_base64
+      unpack1('m*')
+    end
+  end
+end

--- a/lib/keepasshttp/crypto.rb
+++ b/lib/keepasshttp/crypto.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+using Base64Helper
+
+class Keepasshttp
+  # There is a minimal crypto setup necessary for keepass
+  module Crypto
+    attr_reader :session
+    def new_session
+      @session = OpenSSL::Cipher.new('AES-256-CBC')
+      session.encrypt
+    end
+
+    def new_iv
+      iv = session.random_iv
+      @nonce = iv.to_base64
+      @verifier = encrypt(iv.to_base64, iv: iv)
+      iv
+    end
+
+    def encrypt(val, iv:)
+      session.encrypt
+      session.key = @key
+      session.iv = iv
+
+      (session.update(val) + session.final).to_base64
+    end
+
+    def decrypt(string, iv:)
+      session.decrypt
+      session.key = @key
+      session.iv = iv.unpack1('m*')
+
+      session.update(string.unpack1('m*')) + session.final
+    end
+  end
+end

--- a/lib/keepasshttp/formatter.rb
+++ b/lib/keepasshttp/formatter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Keepasshttp
+  # to add more use-cases for the cli provide some output formats so
+  # you can do stuff like:
+  #    ssh $(Keepasshttp example.com --format url)
+  module Formatter
+    def self.as_url(url, dataset)
+      url = URI(url)
+      url.user = dataset['Login']
+      url.password = dataset['Password']
+      url.to_s
+    end
+  end
+end

--- a/lib/keepasshttp/key_store.rb
+++ b/lib/keepasshttp/key_store.rb
@@ -3,11 +3,44 @@
 require 'yaml'
 
 class Keepasshttp
+  # Manage keepasshttp credentials by storing them in various places to reuse
+  # them and prevent popping up keepass dialogs
   module KeyStore
+    using Base64Helper
+
+    def self.list
+      constants.sort.map do |name|
+        klass = const_get(name)
+        next nil unless klass.is_a?(Class)
+
+        klass
+      end.compact
+    end
+
+    def self.init(type)
+      case type
+      when Hash, String then External.new(key_store)
+      when false then nil
+      when :auto
+        use = list.find(&:available?)
+        use ||= Environment
+        use
+      else KeyStore.const_get(type)
+      end
+    rescue StandardError
+      raise ArgumentError, "Invalid key_store #{type.inspect}"
+    end
+
     # Input the key and the id directly into the client so you can take care
     # of the storage yourself.
     class External
-      def initialize(key:, id:)
+      def initialize(token = nil, key: nil, id: nil)
+        if token && key
+          raise ArgumentError, 'Either provide a ID:KEY string or a hash, not' \
+                               ' both'
+        end
+        key, id = string.split(':') if token.is_a?(String)
+
         @params = { key: key, id: id }
       end
 
@@ -22,13 +55,37 @@ class Keepasshttp
       def available?
         true
       end
+
+      def self.available?
+        false
+      end
+    end
+
+    # Read id and key from the KEEPASSHTTP_TOKEN environment variable
+    # you can even use this to store the values but this obviously only
+    # survives within the running ruby process
+    class Environment
+      class << self
+        def load
+          id, key = ENV['KEEPASSHTTP_TOKEN'].split(':')
+          { key: key.from_base64, id: id }
+        end
+
+        def save(id:, key:, **_params)
+          ENV['KEEPASSHTTP_TOKEN'] = [id, key.to_base64].join(':')
+        end
+
+        def available?
+          !ENV['KEEPASSHTTP_TOKEN'].nil?
+        end
+      end
     end
 
     # The most simple but unsecure way wo store your session key (so you don't
     # have to reenter the label over and over again). Use this only for testing!
     class Plain
       # TODO, make the PATH adjustable
-      PATH = File.join(Dir.home, '.keepasshttp-ruby')
+      PATH = File.join(Dir.home, '.config', 'keepasshttp-ruby')
       def self.save(params = {})
         File.write(PATH, params.to_yaml)
       end
@@ -48,7 +105,7 @@ class Keepasshttp
         def available?
           require 'net/ssh'
 
-          super
+          super && File.read(Plain::PATH).match?(/iv:/)
         rescue LoadError
           raise LoadError, 'To use key_store: :SshAgent you have to install ' \
                            "the 'net-ssh' gem"

--- a/spec/keepasshttp_spec.rb
+++ b/spec/keepasshttp_spec.rb
@@ -1,40 +1,50 @@
 # frozen_string_literal: true
 
+Keepasshttp::KeyStore::Plain::PATH = "/tmp/keepasshttp.test.#{rand(1_000_000)}"
+
 RSpec.describe Keepasshttp do
   it 'has a version number' do
     expect(Keepasshttp::VERSION).not_to be nil
   end
 
   context 'Keepasshttp::KeyStore' do
-    it 'has a External format' do
-      ext = Keepasshttp::KeyStore::External.new(id: 'Foo', key: '1234567890')
-
-      expect(ext.available?).to be(true)
-      expect(ext.save(id: 'Bar', key: '0987654321')).to be(false)
-      expect(ext.load).to eq(
-        id: 'Foo', key: '1234567890'
-      )
+    let :credentials do
+      { id: 'Foo', key: '1234567890' }
     end
 
-    it 'has a Plain format' do
-      expect(Keepasshttp::KeyStore::Plain.available?).to be(true)
-      Keepasshttp::KeyStore::Plain.save(id: 'Foo', key: '1234567890')
+    let :changed_credentials do
+      { id: 'Bar', key: '0987654321' }
+    end
+
+    it 'has a External store' do
+      store = Keepasshttp::KeyStore::External
+      expect(store.available?).to be(false)
+
+      store = store.new(credentials)
+
+      expect(store.save(changed_credentials)).to be(false)
+      expect(store.load).to eq(credentials)
+    end
+
+    it 'has a Plain store' do
+      store = Keepasshttp::KeyStore::Plain
+      expect(store.available?).to be(false)
+      store.save(credentials)
+      expect(store.available?).to be(true)
 
       expect(File.read(Keepasshttp::KeyStore::Plain::PATH)).to eq(<<~YAML)
         ---
         :id: Foo
         :key: '1234567890'
       YAML
-
-      expect(Keepasshttp::KeyStore::Plain.load).to eq(
-        id: 'Foo', key: '1234567890'
-      )
+      expect(store.load).to eq(credentials)
     end
 
-    it 'has an SshAgent format (encrypted Plain)' do
-      expect(Keepasshttp::KeyStore::SshAgent.available?).to be(true)
-
-      Keepasshttp::KeyStore::SshAgent.save(id: 'Foo', key: '1234567890')
+    it 'has an SshAgent store (encrypted Plain)' do
+      store = Keepasshttp::KeyStore::SshAgent
+      expect(store.available?).to be(false)
+      store.save(credentials)
+      expect(store.available?).to be(true)
 
       cfg_file = File.read(Keepasshttp::KeyStore::Plain::PATH)
       expect(cfg_file).to match(/id: Foo/)
@@ -42,15 +52,26 @@ RSpec.describe Keepasshttp do
       expect(cfg_file).to_not match(/1234567890/)
       expect(cfg_file).to match(/iv:/)
 
-      expect(Keepasshttp::KeyStore::SshAgent.load).to eq(
-        id: 'Foo', key: '1234567890'
-      )
+      expect(store.load).to eq(credentials)
+    end
+
+    it 'has an Environment store' do
+      store = Keepasshttp::KeyStore::Environment
+
+      expect(store.available?).to be(false)
+      ENV['KEEPASSHTTP_TOKEN'] = 'Foo:MTIzNDU2Nzg5MA=='
+      expect(store.available?).to be(true)
+
+      expect(store.load).to eq(credentials)
+
+      store.save(changed_credentials)
+      expect(store.load).to eq(changed_credentials)
     end
   end
 
   context 'Client' do
     it 'can login to an opened Keepass' do
-      kee = Keepasshttp.connect
+      kee = Keepasshttp.connect(key_store: false)
       expect(kee.id).to eq('Test')
     end
 


### PR DESCRIPTION
After several weeks of silence I hopped back into working on this stuff mainly because I have a real use-case again (the project it was originally intended for was cancelled). So

* Add an Environment store to fetch the credentials from a variable.
* Add an key_store: :auto flag which tries to find the available store on it's own
* Default key_store is now :auto
* Rearrange some code
* [CLI] Some rework for match the keystore changes and add a format option
